### PR TITLE
timeの設定範囲を定義

### DIFF
--- a/src/model/BlockModel.java
+++ b/src/model/BlockModel.java
@@ -50,6 +50,12 @@ public class BlockModel {
 
     public void setTime(int value) {
         // 入力上は1000秒で1秒だが、ロボット側では、10で1秒のため
+        if (value < 100) {
+            value = 100;
+        } else if (value >= 100000) {
+            value = 99900;
+        }
+
         this.value2 = value / 100;
     }
 


### PR DESCRIPTION
現状の下限と上限の時間設定範囲が甘いのでfix

0.1秒(time = 100)未満で設定された場合は0.1秒で設定、
100秒(time = 100000)以上では桁あふれするので、設定された場合は99.9秒(time = 99900)で設定。

999900 ~ 999999 とかは99.9秒に切り捨てられるよう既になっているので問題ない